### PR TITLE
impr: added a script to sync manifest and package.json versions. Runned automatically on 'yarn version'

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -8,7 +8,9 @@
   "source": "git://github.com/konnectors/cozy-konnector-directenergie.git",
   "editor": "Brice Coquereau",
   "vendor_link": "https://clients.direct-energie.com/connexion-clients-particuliers/",
-  "categories": ["energy"],
+  "categories": [
+    "energy"
+  ],
   "fields": {
     "login": {
       "type": "email"
@@ -38,14 +40,19 @@
     },
     "accounts": {
       "type": "io.cozy.accounts",
-      "verbs": ["GET"]
+      "verbs": [
+        "GET"
+      ]
     }
   },
   "developer": {
     "name": "Brice Coquereau",
     "url": "brice@coquereau.fr"
   },
-  "langs": ["fr", "en"],
+  "langs": [
+    "fr",
+    "en"
+  ],
   "locales": {
     "fr": {
       "short_description": "Récupère toutes factures et échéanciers Direct Energie",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "deploy": "git-directory-deploy --directory build/ --branch ${DEPLOY_BRANCH:-build} --repo=${DEPLOY_REPOSITORY:-https://$GITHUB_TOKEN@github.com/konnectors/cozy-konnector-directenergie.git}",
     "cozyPublish": "cozy-app-publish --token $REGISTRY_TOKEN --build-commit $(git rev-parse ${DEPLOY_BRANCH:-build})",
     "publish:cozy": "git fetch origin ${DEPLOY_BRANCH:-build}:${DEPLOY_BRANCH:-build} && cozy-app-publish --token $REGISTRY_TOKEN --build-commit $(git rev-parse ${DEPLOY_BRANCH:-build})",
-    "travisDeployKey": "./bin/generate_travis_deploy_key"
+    "travisDeployKey": "./bin/generate_travis_deploy_key",
+    "version": "node update_manifest_version.js && git add manifest.konnector"
   },
   "dependencies": {
     "cozy-konnector-libs": "4.4.0"

--- a/update_manifest_version.js
+++ b/update_manifest_version.js
@@ -1,0 +1,8 @@
+const fs = require('fs')
+
+const packageJson = JSON.parse(fs.readFileSync('package.json'))
+const manifestJson = JSON.parse(fs.readFileSync('manifest.konnector'))
+
+manifestJson.version = packageJson.version
+
+fs.writeFileSync('manifest.konnector', JSON.stringify(manifestJson, null, 2))


### PR DESCRIPTION
While adding my token for travis, I noticed that, when bumping the version with "yarn version --patch", the manifest's version was not updated, so the deploy was failing because of the different versions.

I added a script, launched after the version bump (https://docs.npmjs.com/cli/version).

Maybe it can be moved to cozy-app-publish? I feel that it's going to be a problem for other people in the future. Your call.