### PR TITLE
feat: Remove useless navigation for bill fetching

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,8 +12,8 @@ const HOMEPAGE_URL =
   'https://www.totalenergies.fr/clients/accueil#fz-authentificationForm'
 const contractSelectionPage =
   'https://www.totalenergies.fr/clients/selection-compte'
-const contactInfosPage =
-  'https://www.totalenergies.fr/clients/mon-compte/mes-infos-de-contact'
+// const contactInfosPage =
+//   'https://www.totalenergies.fr/clients/mon-compte/mes-infos-de-contact'
 // Keeping this urls around in case they're needed in the future
 // const billsPage = 'https://www.totalenergies.fr/clients/mes-factures'
 // const billsHistoricPage =
@@ -436,20 +436,6 @@ class TemplateContentScript extends ContentScript {
         await Promise.race([
           this.waitForElementInWorker(
             'a[href="/clients/mon-compte/gerer-mes-comptes"]'
-          ),
-          this.waitForErrors()
-        ])
-        if (this.store.foundError) {
-          await this.handleError()
-        }
-        await this.runInWorker(
-          'removeElement',
-          'a[href="/clients/mes-factures/mon-historique-de-factures"]'
-        )
-        await this.goto(contactInfosPage)
-        await Promise.race([
-          this.waitForElementInWorker(
-            'a[href="/clients/mes-factures/mon-historique-de-factures"]'
           ),
           this.waitForErrors()
         ])


### PR DESCRIPTION
This PR removes useless navigation done after fetching the docs to save for other (other than the first) contracts.

We were trying to reach the contactInfos page when there is no need to, leading the konnector to crash on an awaited element because it did not showed up. This was not seen until now because of the account use to develop this CLISK : The account did not have contactInfo for it's second contract so the website would redirect the contactInfosPage url to the homePage. Because of this, the konnector was able to find the billsPage href, and continues its execution like nothing happen. As we were absolutely not fetching anything on the contactInfosPage (even if the account used would have contactInfos for other contracts),we're now avoiding losing execution time by not going to this page.

It should fix the `waitForElementInWorker('a[href="/clients/mes-factures/mon-historique-de-factures"]')` error we got on some user's execution.