### PR TITLE
[SCR-568] fix: Ensure checking good link to define uniqContract

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -262,12 +262,15 @@ class TemplateContentScript extends ContentScript {
     )
     if (!isContractSelectionPage) {
       this.log('info', 'Landed on the home page after login')
-      const changeAccountLink = await this.isElementInWorker(
-        'a[href="/clients/mon-compte/gerer-mes-comptes"]'
+      // Carefull here, there are at least 4 links with this href on the account used to dev
+      // The id here is to ensure we're checking for the one actually interesting to us at this moment
+      const changeContractLink = await this.isElementInWorker(
+        '#contenu a[href="/clients/mon-compte/gerer-mes-comptes"]'
       )
-      if (changeAccountLink) {
+      if (changeContractLink) {
+        this.log('info', 'Found changeContract link')
         await this.clickAndWait(
-          'a[href="/clients/mon-compte/gerer-mes-comptes"]',
+          '#contenu a[href="/clients/mon-compte/gerer-mes-comptes"]',
           '[id*="js--listjs-comptes-"]'
         )
         isContractSelectionPage = true
@@ -279,6 +282,7 @@ class TemplateContentScript extends ContentScript {
       this.log('info', 'Landed on the contracts selection page after login')
     }
     if (!uniqContract) {
+      this.log('info', 'Is not uniqContract')
       const foundContractsNumber = await this.getNumberOfContracts()
       this.log('info', `Found ${foundContractsNumber} contracts`)
       numberOfContracts = foundContractsNumber


### PR DESCRIPTION
We're suspecting changeContract link is not visible to user with only one contract, but still accessible with JS in the HTML.

During the investigation, It was noticed that we got at least 4 elements containing the expected href with the account used to dev.
With previous method, we were checking with a simple querySelector, leading the next click to be done on the first found element with wanted href and this was inducing an error for some users (presumably because the click was not made at all because no elements were actually clickable OR because the element is present but do nothing when clicked, as user have only 1 contract).

This could not have been tested properly as mentionning above, the account we dispose is not in this case. But at least it ensures we're looking for the right link to check.