### PR TITLE
fix: Avoid clientRef and .detail-factures errors (SCR-811)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -449,6 +449,10 @@ class TemplateContentScript extends ContentScript {
     if (this.store.userCredentials) {
       await this.saveCredentials(this.store.userCredentials)
     }
+    if (!clientRefs) {
+      this.log('warn', 'Found no contract. clientRefs is empty')
+      return true
+    }
     for (let i = 0; i < numberOfContracts; i++) {
       const billsDone = await this.fetchBills()
       if (billsDone) {


### PR DESCRIPTION
When the user does not have any contract. Do not raise an error.
Identity is still fetched
