### PR TITLE
[SCR-920] fix: Adapt contract parent element's scraping

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -839,9 +839,12 @@ class TemplateContentScript extends ContentScript {
 
   async getContract() {
     this.log('info', 'getContract starts')
-    const contractElement = document.querySelector('.arrondi-04')
+    const contractElement = document.querySelector(
+      '[data-cs-override-id="offreDescription"]'
+    )
     const offerName = contractElement
-      .querySelector('[data-cs-override-id="offreDescription"] > p')
+      // First p tag is the starting date of the contract
+      .querySelector('p')
       .innerHTML.replace(/  {2}|\n/g, '')
       .trim()
     const rawStartDate = contractElement.querySelector(


### PR DESCRIPTION
Small adaptation as the website removed the class we used to scrap contract info